### PR TITLE
Fixed device classes for var and VA sensors

### DIFF
--- a/esphome_example_code/em340.yaml
+++ b/esphome_example_code/em340.yaml
@@ -215,7 +215,7 @@ sensor:
     register_type: read
     value_type: S_DWORD_R
     accuracy_decimals: 1
-    device_class: power
+    device_class: apparent_power
     filters:
       - multiply: 0.1
 
@@ -228,7 +228,7 @@ sensor:
     register_type: read
     value_type: S_DWORD_R
     accuracy_decimals: 1
-    device_class: power
+    device_class: apparent_power 
     filters:
       - multiply: 0.1
 
@@ -241,7 +241,7 @@ sensor:
     register_type: read
     value_type: S_DWORD_R
     accuracy_decimals: 1
-    device_class: power
+    device_class: apparent_power
     filters:
       - multiply: 0.1
 
@@ -254,7 +254,7 @@ sensor:
     register_type: read
     value_type: S_DWORD_R
     accuracy_decimals: 1
-    device_class: power
+    device_class: reactive_power
     filters:
       - multiply: 0.1
 
@@ -267,7 +267,7 @@ sensor:
     register_type: read
     value_type: S_DWORD_R
     accuracy_decimals: 1
-    device_class: power
+    device_class: reactive_power
     filters:
       - multiply: 0.1
 
@@ -280,7 +280,7 @@ sensor:
     register_type: read
     value_type: S_DWORD_R
     accuracy_decimals: 1
-    device_class: power
+    device_class: reactive_power
     filters:
       - multiply: 0.1
 
@@ -332,7 +332,7 @@ sensor:
     register_type: read
     value_type: S_DWORD_R
     accuracy_decimals: 1
-    device_class: power
+    device_class: apparent_power
     filters:
       - multiply: 0.1
 
@@ -345,7 +345,7 @@ sensor:
     register_type: read
     value_type: S_DWORD_R
     accuracy_decimals: 1
-    device_class: power
+    device_class: reactive_power
     filters:
       - multiply: 0.1
 


### PR DESCRIPTION
kVAL* had device class "power", should have been "apparent_power"
VA* had device_class "power", should have been "reactive_power"